### PR TITLE
Add export filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Usage:
 1. Open terminal app
 2. Execute `npx github:hagent/export-macos-podcasts` command
 
+To export a subset of podcasts, add one or more arguments.  Only podcasts whose series name or file name matches any argument will be included.  For example: `npx github:hagent/export-macos-podcasts Radio`
+
 Alternatively you can clone repository:
 1. Clone/Download repository (unarchive it if it was archived)
 2. Open terminal at downloaded folder (context click on folder -> services -> New Terminal at folder or just open Terminal app and execute `cd [REPOSITORY FOLDER]`)

--- a/index.js
+++ b/index.js
@@ -96,7 +96,6 @@ original error: ${e}`);
   }
 }
 
-
 async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData) {
   const uuid = fileName.replace(".mp3", "");
   const dbMeta = podcastsDBData.find((m) => m.zuuid === uuid);
@@ -106,7 +105,7 @@ async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData
         ?? uuid; // 3. fallback to unreadable uuid
   const podcastName = sanitize(dbMeta?.zpodcast);
   const exportFileName = sanitize(exportBase.substr(0, fileNameMaxLength));
-  const date = dbMeta?.date
+  const date = dbMeta?.date;
 
   return {
     podcastName,
@@ -118,30 +117,28 @@ async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData
   };
 }
 
-
 function filterPodcasts(podcasts, filepatterns = []) {
-  if (filepatterns.length == 0) {
+  if (filepatterns.length === 0) {
     return podcasts;
   }
 
   function matchesAny(fileOrDir) {
     return filepatterns
-      .map(pattern => pattern.toLowerCase())
-      .some(pattern => fileOrDir.toLowerCase().includes(pattern) )
+      .map((pattern) => pattern.toLowerCase())
+      .some((pattern) => fileOrDir.toLowerCase().includes(pattern));
   }
 
-  return podcasts.filter((p) => {
-    return matchesAny(p.exportFileName) || matchesAny(p.podcastName);
-  });
+  return podcasts.filter((p) =>
+    matchesAny(p.exportFileName) || matchesAny(p.podcastName)
+  );
 }
-
 
 async function exportPodcasts(podcastsDBData, filepatterns = []) {
   const cacheFilesPath = await getPodcastsCacheFilesPath();
   const podcastMP3Files = await getPodcastsCacheMP3Files(cacheFilesPath);
-  const podcasts = await Promise.all(podcastMP3Files.map((fileName) => {
-    return mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData);
-  }));
+  const podcasts = await Promise.all(podcastMP3Files.map((fileName) =>
+    mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData)
+  ));
   const filteredPodcasts = filterPodcasts(podcasts, filepatterns);
   if (filepatterns.length > 0) {
     console.log(`Exporting ${filteredPodcasts.length} of ${podcasts.length}`);
@@ -164,9 +161,9 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
       const newPath = `${exportDirPath}/${podcast.exportFileName}`;
       await fs.copyFile(podcast.path, newPath);
 
-      const logDestFilePath = [ podcast.podcastName, podcast.exportFileName ].
-            filter((s) => s).
-            join('/');
+      const logDestFilePath = [podcast.podcastName, podcast.exportFileName]
+        .filter((s) => s)
+        .join("/");
       console.log(`${podcast.fileName} -> ${logDestFilePath}`);
       if (podcast.date) {
         const d = new Date(podcast.date);
@@ -183,5 +180,5 @@ async function main(filepatterns = []) {
   await exportPodcasts(dbPodcastData, filepatterns);
 }
 
-var args = process.argv.slice(2);
+const args = process.argv.slice(2);
 main(args);

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ async function buildPodcastDict(fileName, cacheFilesPath, podcastsDBData) {
   const exportBase = dbMeta?.zcleanedtitle // 1. from apple podcast database
         ?? (await getMP3MetaTitle(path)) // 2. from mp3 meta data
         ?? uuid; // 3. fallback to unreadable uuid
-  const podcastName = dbMeta?.zpodcast.replaceAll('/', '_');
+  const podcastName = sanitize(dbMeta?.zpodcast);
   const exportFileName = sanitize(exportBase.substr(0, fileNameMaxLength));
   const date = dbMeta?.date
 

--- a/index.js
+++ b/index.js
@@ -162,7 +162,11 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
 
       const newPath = `${exportDirPath}/${podcast.exportFileName}`;
       await fs.copyFile(podcast.path, newPath);
-      console.log(`${podcast.path} -> ${newPath}`);
+
+      const logName = [ podcast.podcastName, podcast.exportFileName ].
+            filter((s) => s).
+            join('/');
+      console.log(`${podcast.fileName} -> ${logName}`);
       if (podcast.date) {
         const d = new Date(podcast.date);
         await fs.utimes(newPath, d, d);

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ original error: ${e}`);
 }
 
 
-async function buildPodcastDict(fileName, cacheFilesPath, podcastsDBData) {
+async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData) {
   const uuid = fileName.replace(".mp3", "");
   const dbMeta = podcastsDBData.find((m) => m.zuuid === uuid);
   const path = `${cacheFilesPath}/${fileName}`;
@@ -141,7 +141,7 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
   const cacheFilesPath = await getPodcastsCacheFilesPath();
   const podcastMP3Files = await getPodcastsCacheMP3Files(cacheFilesPath);
   const podcasts = await Promise.all(podcastMP3Files.map((fileName) => {
-    return buildPodcastDict(fileName, cacheFilesPath, podcastsDBData);
+    return mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData);
   }));
   const filteredPodcasts = filterPodcasts(podcasts, filepatterns);
   if (filepatterns.length > 0) {

--- a/index.js
+++ b/index.js
@@ -125,16 +125,12 @@ function filterPodcasts(podcasts, filepatterns = []) {
     return podcasts;
   }
 
-  function matchesAnyFilepattern(s) {
-    const indices = filepatterns.map((fp) => {
-      return s.indexOf(fp);
-    });
-    const found = indices.filter((i) => { return i != -1; });
-    return found.length > 0;
+  function matchesAny(s) {
+    return filepatterns.some((p) => { return s.indexOf(p) != -1 })
   }
 
   return podcasts.filter((p) => {
-    return matchesAnyFilepattern(p.exportFileName);
+    return matchesAny(p.exportFileName);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ async function exportPodcasts(podcastsDBData) {
     filesWithDBData.map(async (podcast) => {
       // Create an export subdir
       let exportDirPath = outputDir;
-      const exportDir = podcast.dbMeta?.zpodcast;
+      const exportDir = podcast.dbMeta?.zpodcast.replaceAll('/', '_');
       if (exportDir) {
         exportDirPath = `${outputDir}/${exportDir}`;
         // Needs to be sync else the same dir can be created multiple times

--- a/index.js
+++ b/index.js
@@ -125,8 +125,10 @@ function filterPodcasts(podcasts, filepatterns = []) {
     return podcasts;
   }
 
-  function matchesAny(s) {
-    return filepatterns.some((p) => { return s.indexOf(p) != -1 })
+  function matchesAny(fileOrDir) {
+    return filepatterns
+      .map(pattern => pattern.toLowerCase())
+      .some(pattern => fileOrDir.toLowerCase().includes(pattern) )
   }
 
   return podcasts.filter((p) => {

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function filterPodcasts(podcasts, filepatterns = []) {
   }
 
   return podcasts.filter((p) => {
-    return matchesAny(p.exportFileName);
+    return matchesAny(p.exportFileName) || matchesAny(p.podcastName);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData
   const exportFileName = sanitize(exportBase.substr(0, fileNameMaxLength));
   const date = dbMeta?.date
 
-  const ret = {
+  return {
     podcastName,
     date,
     fileName,
@@ -116,7 +116,6 @@ async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData
     uuid,
     exportFileName: `${exportFileName}.mp3`
   };
-  return ret;
 }
 
 

--- a/index.js
+++ b/index.js
@@ -128,17 +128,13 @@ function filterPodcasts(podcasts, filepatterns = []) {
       .some((pattern) => fileOrDir.toLowerCase().includes(pattern));
   }
 
-  return podcasts.filter((p) =>
-    matchesAny(p.exportFileName) || matchesAny(p.podcastName)
-  );
+  return podcasts.filter((p) => matchesAny(p.exportFileName) || matchesAny(p.podcastName));
 }
 
 async function exportPodcasts(podcastsDBData, filepatterns = []) {
   const cacheFilesPath = await getPodcastsCacheFilesPath();
   const podcastMP3Files = await getPodcastsCacheMP3Files(cacheFilesPath);
-  const podcasts = await Promise.all(podcastMP3Files.map((fileName) =>
-    mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData)
-  ));
+  const podcasts = await Promise.all(podcastMP3Files.map((fileName) => mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData)));
   const filteredPodcasts = filterPodcasts(podcasts, filepatterns);
   if (filepatterns.length > 0) {
     console.log(`Exporting ${filteredPodcasts.length} of ${podcasts.length}`);

--- a/index.js
+++ b/index.js
@@ -165,10 +165,10 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
       const newPath = `${exportDirPath}/${podcast.exportFileName}`;
       await fs.copyFile(podcast.path, newPath);
 
-      const logName = [ podcast.podcastName, podcast.exportFileName ].
+      const logDestFilePath = [ podcast.podcastName, podcast.exportFileName ].
             filter((s) => s).
             join('/');
-      console.log(`${podcast.fileName} -> ${logName}`);
+      console.log(`${podcast.fileName} -> ${logDestFilePath}`);
       if (podcast.date) {
         const d = new Date(podcast.date);
         await fs.utimes(newPath, d, d);

--- a/index.js
+++ b/index.js
@@ -96,18 +96,24 @@ original error: ${e}`);
   }
 }
 
+
+function buildPodcastDict(fileName, cacheFilesPath, podcastsDBData) {
+  const uuid = fileName.replace(".mp3", "");
+  const dbMeta = podcastsDBData.find((m) => m.zuuid === uuid);
+  return {
+    fileName,
+    uuid,
+    path: `${cacheFilesPath}/${fileName}`,
+    dbMeta
+  };
+}
+
+
 async function exportPodcasts(podcastsDBData) {
   const cacheFilesPath = await getPodcastsCacheFilesPath();
   const podcastMP3Files = await getPodcastsCacheMP3Files(cacheFilesPath);
   const filesWithDBData = podcastMP3Files.map((fileName) => {
-    const uuid = fileName.replace(".mp3", "");
-    const dbMeta = podcastsDBData.find((m) => m.zuuid === uuid);
-    return {
-      fileName,
-      uuid,
-      path: `${cacheFilesPath}/${fileName}`,
-      dbMeta
-    };
+    return buildPodcastDict(fileName, cacheFilesPath, podcastsDBData);
   });
   const outputDir = getOutputDirPath();
   await fs.mkdir(outputDir, { recursive: true });


### PR DESCRIPTION
This PR has two things:

* separates the podcast file data collection from actual podcast export (cleans up the export code, and allows for simpler filtering)
* adds filtering

I wanted the code to only export a few things, b/c I only had a handful of podcasts I was interested in.  With this PR, I could run the code as:

```
$ node index.js constan mied

Exporting 9 of 448
56F32137-FD0A-41EC-9A9D-37501B90C1BA.mp3 -> TED en Español/El miedo, el dolor y la comunicación  José Nesis.mp3
32DE1C6F-9BA5-4E16-A051-5FD66A79F5D7.mp3 -> Intermediate Spanish Podcast - Español Intermedio/E05 La constancia.mp3
... [etc]


Successful Export to '/Users/jeff/Downloads/PodcastsExport/2022.05.13' folder!
```