### PR TITLE
Add command-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,28 @@ Usage:
 1. Open terminal app
 2. Execute `npx github:hagent/export-macos-podcasts` command
 
-To export a subset of podcasts, add one or more arguments.  Only podcasts whose series name or file name matches any argument will be included.  For example: `npx github:hagent/export-macos-podcasts Radio`
+You can use some command-line arguments as well for further control:
+
+```
+$ node index.js -h
+Options:
+      --version     Show version number                                [boolean]
+  -o, --outputdir   Base output directory
+                                [string] [default: "~/Downloads/PodcastsExport"]
+  -d, --datesubdir  Add YYYY.MM.DD subdirectory to output dir
+                                                       [boolean] [default: true]
+  -p, --pattern     File substring patterns to match                    [string]
+      --nospaces    Replace filename spaces with underscores
+                                                      [boolean] [default: false]
+  -h, --help        Show help                                          [boolean]
+```
+
+For example, the below command will export podcasts matching the strings "tregua" or "miedo" to the "~/Downloads/some/folder" director, and will not create "YYYY.MM.DD" subfolder under that.  "--nospaces" indicates that the downloaded file names should not contain any spaces, which is sometimes useful for file management.
+
+```
+$ node index.js -p tregua -p miedo -o ~/Downloads/some/folder --datesubfolder false --nospaces
+```
+
 
 Alternatively you can clone repository:
 1. Clone/Download repository (unarchive it if it was archived)

--- a/index.js
+++ b/index.js
@@ -55,12 +55,16 @@ const podcastSelectSQL = `
 const fileNameMaxLength = 50;
 
 function getOutputDirPath() {
-  const d = new Date();
-  const pad = (s) => s.toString().padStart(2, "0");
-  const month = pad(d.getMonth() + 1);
-  const day = pad(d.getDate());
-  const currentDateFolder = `${d.getFullYear()}.${month}.${day}`;
-  return `${process.env.HOME}/Downloads/PodcastsExport/${currentDateFolder}`;
+  let ret = argv.outputdir;
+  if (argv.datesubdir) {
+    const d = new Date();
+    const pad = (s) => s.toString().padStart(2, "0");
+    const month = pad(d.getMonth() + 1);
+    const day = pad(d.getDate());
+    const currentDateFolder = `${d.getFullYear()}.${month}.${day}`;
+    ret = `${ret}/${currentDateFolder}`;
+  }
+  return ret;
 }
 
 async function getPodcastsBasePath() {

--- a/index.js
+++ b/index.js
@@ -247,17 +247,18 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
   exec(`open ${outputDir}`);
 }
 
-async function main(filepatterns = []) {
+async function main() {
   const dbPodcastData = await tryGetDBPodcastsData();
-  await exportPodcasts(dbPodcastData, filepatterns);
+
+  // Default: return all files.
+  let patterns = [];
+  if (argv.pattern) {
+    // User might specify one pattern, in which case argv.pattern is a
+    // string, or multiple, in which case it's an array.
+    patterns = [ argv.pattern ].flat();
+  }
+  await exportPodcasts(dbPodcastData, patterns);
 }
 
-// Default: return all files.
-let patterns = []
-if (argv.pattern) {
-  // User might specify one pattern, in which case argv.pattern is a
-  // string, or multiple, in which case it's an array.
-  patterns = [ argv.pattern ].flat();
-}
 
-main(patterns);
+main();

--- a/index.js
+++ b/index.js
@@ -172,6 +172,14 @@ function filterPodcasts(podcasts, filepatterns = []) {
   return podcasts.filter((p) => matchesAny(p.exportFileName) || matchesAny(p.podcastName));
 }
 
+async function exportSingle(podcast, newPath) {
+  await fs.copyFile(podcast.path, newPath);
+  if (podcast.date) {
+    const d = new Date(podcast.date);
+    await fs.utimes(newPath, d, d);
+  }
+}
+
 async function exportPodcasts(podcastsDBData, filepatterns = []) {
   const cacheFilesPath = await getPodcastsCacheFilesPath();
   const podcastMP3Files = await getPodcastsCacheMP3Files(cacheFilesPath);
@@ -199,16 +207,11 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
       }
 
       const newPath = `${exportDirPath}/${podcast.exportFileName}`;
-      await fs.copyFile(podcast.path, newPath);
-
-      const logDestFilePath = [podcast.podcastName, podcast.exportFileName]
-        .filter((s) => s)
-        .join("/");
+      await exportSingle(podcast, newPath);
+      const logDestFilePath = [ podcast.podcastName, podcast.exportFileName ].
+        filter((s) => s).
+        join('/');
       console.log(`${podcast.fileName} -> ${logDestFilePath}`);
-      if (podcast.date) {
-        const d = new Date(podcast.date);
-        await fs.utimes(newPath, d, d);
-      }
     })
   );
   console.log(`\n\nSuccessful Export to '${outputDir}' folder!`);

--- a/index.js
+++ b/index.js
@@ -25,20 +25,10 @@ const argv = yargs
         description: 'File substring patterns to match',
         type: 'string'
       })
-      .option('silent', {
-        description: 'Suppress extra output',
-        type: 'boolean',
-        default: false
-      })
       .option('nospaces', {
         description: 'Replace filename spaces with underscores',
         type: 'boolean',
-        default: true
-      })
-      .option('report', {
-        description: 'Provide report at end of files downloaded',
-        type: 'boolean',
-        default: true
+        default: false
       })
       .help()
       .alias('help', 'h').argv;
@@ -139,6 +129,15 @@ original error: ${e}`);
   }
 }
 
+function handleSpaces(s) {
+  ret = s;
+  if (argv.nospaces) {
+    ret = s.replaceAll(' ', '_');
+  }
+  return ret;
+}
+
+
 async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData) {
   const uuid = fileName.replace(".mp3", "");
   const dbMeta = podcastsDBData.find((m) => m.zuuid === uuid);
@@ -148,15 +147,14 @@ async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData
         ?? uuid; // 3. fallback to unreadable uuid
   const podcastName = sanitize(dbMeta?.zpodcast);
   const exportFileName = sanitize(exportBase.substr(0, fileNameMaxLength));
-  const date = dbMeta?.date;
 
   return {
-    podcastName,
-    date,
+    podcastName: handleSpaces(podcastName),
+    date: dbMeta?.date,
     fileName,
     path,
     uuid,
-    exportFileName: `${exportFileName}.mp3`
+    exportFileName: handleSpaces(`${exportFileName}.mp3`)
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,45 @@ const mm = require("music-metadata");
 const { exec } = require("child_process");
 const sanitize = require("sanitize-filename");
 
+const yargs = require('yargs');
+
+const argv = yargs
+      .option('outputdir', {
+        alias: 'o',
+        description: 'Base output directory',
+        type: 'string',
+        default: `${process.env.HOME}/Downloads/PodcastsExport`
+      })
+      .option('datesubdir', {
+        alias: 'd',
+        description: 'Add YYYY.MM.DD subdirectory to output dir',
+        type: 'boolean',
+        default: true
+      })
+      .option('pattern', {
+        alias: 'p',
+        description: 'File substring patterns to match',
+        type: 'string'
+      })
+      .option('silent', {
+        description: 'Suppress extra output',
+        type: 'boolean',
+        default: false
+      })
+      .option('nospaces', {
+        description: 'Replace filename spaces with underscores',
+        type: 'boolean',
+        default: true
+      })
+      .option('report', {
+        description: 'Provide report at end of files downloaded',
+        type: 'boolean',
+        default: true
+      })
+      .help()
+      .alias('help', 'h').argv;
+
+
 // Added the Podcast name to the query
 // Looks like the date stored in the SQLite has an offset of +31 years, so we adjust the query
 const podcastSelectSQL = `

--- a/index.js
+++ b/index.js
@@ -222,5 +222,8 @@ async function main(filepatterns = []) {
   await exportPodcasts(dbPodcastData, filepatterns);
 }
 
-const args = process.argv.slice(2);
-main(args);
+// User might specify one pattern, in which case argv.pattern is a
+// string, or multiple, in which case it's an array.
+patterns = [ argv.pattern ].flat()
+
+main(patterns);

--- a/index.js
+++ b/index.js
@@ -4,41 +4,39 @@ const sqlite3 = require("sqlite3").verbose();
 const mm = require("music-metadata");
 const { exec } = require("child_process");
 const sanitize = require("sanitize-filename");
-
-const yargs = require('yargs');
+const yargs = require("yargs");
 
 const argv = yargs
-      .option('outputdir', {
-        alias: 'o',
-        description: 'Base output directory',
-        type: 'string',
-        default: `${process.env.HOME}/Downloads/PodcastsExport`
-      })
-      .option('datesubdir', {
-        alias: 'd',
-        description: 'Add YYYY.MM.DD subdirectory to output dir',
-        type: 'boolean',
-        default: true
-      })
-      .option('pattern', {
-        alias: 'p',
-        description: 'File substring patterns to match',
-        type: 'string'
-      })
-      .option('updateutime', {
-        alias: 'u',
-        description: 'Update the utime of the downloaded files',
-        type: 'boolean',
-        default: false
-      })
-      .option('nospaces', {
-        description: 'Replace filename spaces with underscores',
-        type: 'boolean',
-        default: false
-      })
-      .help()
-      .alias('help', 'h').argv;
-
+  .option("outputdir", {
+    alias: "o",
+    description: "Base output directory",
+    type: "string",
+    default: `${process.env.HOME}/Downloads/PodcastsExport`
+  })
+  .option("datesubdir", {
+    alias: "d",
+    description: "Add YYYY.MM.DD subdirectory to output dir",
+    type: "boolean",
+    default: true
+  })
+  .option("pattern", {
+    alias: "p",
+    description: "File substring patterns to match",
+    type: "string"
+  })
+  .option("updateutime", {
+    alias: "u",
+    description: "Update the utime of the downloaded files",
+    type: "boolean",
+    default: false
+  })
+  .option("nospaces", {
+    description: "Replace filename spaces with underscores",
+    type: "boolean",
+    default: false
+  })
+  .help()
+  .alias("help", "h").argv;
 
 // Added the Podcast name to the query
 // Looks like the date stored in the SQLite has an offset of +31 years, so we adjust the query
@@ -136,13 +134,12 @@ original error: ${e}`);
 }
 
 function handleSpaces(s) {
-  ret = s;
+  let ret = s;
   if (argv.nospaces) {
-    ret = s.replaceAll(' ', '_');
+    ret = s.replaceAll(" ", "_");
   }
   return ret;
 }
-
 
 async function mergeFilesWithDBMetaData(fileName, cacheFilesPath, podcastsDBData) {
   const uuid = fileName.replace(".mp3", "");
@@ -199,7 +196,7 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
   // filename).  Since this causes some strange messages to appear
   // during export (i.e, the same podcast name is output several times),
   // delete the dups by keying on filename.
-  const uniqByFilename = Object.fromEntries(filteredPodcasts.map(p => [p.exportFileName, p]));
+  const uniqByFilename = Object.fromEntries(filteredPodcasts.map((p) => [p.exportFileName, p]));
   filteredPodcasts = Object.values(uniqByFilename);
 
   if (filepatterns.length > 0) {
@@ -207,18 +204,16 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
   }
 
   function joinPath(parts) {
-    return parts.filter((s) => s).join('/');
+    return parts.filter((s) => s).join("/");
   }
 
   // Make all necessary directories.  Each podcast is in its own
   // subdir.
   const outputDir = getOutputDirPath();
-  const allDirs = filteredPodcasts.map(p => {
-    return joinPath([outputDir, p.podcastName]);
-  });
+  const allDirs = filteredPodcasts.map((p) => joinPath([outputDir, p.podcastName]));
   const uniqueDirs = Array.from(new Set(allDirs));
   // console.log(`Making ${uniqueDirs.length} directories ...`);
-  uniqueDirs.forEach(d => mkdirSync(d, { recursive: true }));
+  uniqueDirs.forEach((d) => mkdirSync(d, { recursive: true }));
   // console.log(`Done making ${uniqueDirs.length} directories.`);
 
   let skipped = 0;
@@ -232,8 +227,7 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
       if (!existsSync(newPath)) {
         console.log(`${p.fileName} -> ${logDestFilePath}`);
         await exportSingle(p, newPath);
-      }
-      else {
+      } else {
         skipped += 1;
         console.log(`Already have ${logDestFilePath}, skipping`);
       }
@@ -255,10 +249,9 @@ async function main() {
   if (argv.pattern) {
     // User might specify one pattern, in which case argv.pattern is a
     // string, or multiple, in which case it's an array.
-    patterns = [ argv.pattern ].flat();
+    patterns = [argv.pattern].flat();
   }
   await exportPodcasts(dbPodcastData, patterns);
 }
-
 
 main();

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
   // filename).  Since this causes some strange messages to appear
   // during export (i.e, the same podcast name is output several times),
   // delete the dups by keying on filename.
-  const uniqByFilename = Object.fromEntries(filteredPodcasts.map(p => [p.exportFileName, p]))
+  const uniqByFilename = Object.fromEntries(filteredPodcasts.map(p => [p.exportFileName, p]));
   filteredPodcasts = Object.values(uniqByFilename);
 
   if (filepatterns.length > 0) {
@@ -234,7 +234,7 @@ async function exportPodcasts(podcastsDBData, filepatterns = []) {
         await exportSingle(p, newPath);
       }
       else {
-        skipped += 1
+        skipped += 1;
         console.log(`Already have ${logDestFilePath}, skipping`);
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "music-metadata": "^7.8.7",
         "sanitize-filename": "^1.6.3",
         "semver": "^5.3.0",
-        "sqlite3": "^5.0.2"
+        "sqlite3": "^5.0.2",
+        "yargs": "^17.5.0"
       },
       "bin": {
         "export-macos-podcasts": "exportVersionCheck.js"
@@ -217,7 +218,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -407,6 +407,56 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -419,7 +469,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -430,8 +479,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -596,6 +644,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -657,6 +710,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1191,6 +1252,14 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2489,6 +2558,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -2966,15 +3043,144 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "node_modules/yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   },
   "dependencies": {
@@ -3127,7 +3333,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -3278,6 +3483,46 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -3287,7 +3532,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -3295,8 +3539,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3427,6 +3670,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -3474,6 +3722,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -3889,6 +4142,11 @@
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
       }
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -4859,6 +5117,11 @@
         "uuid": "^3.3.2"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -5226,15 +5489,109 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "music-metadata": "^7.8.7",
     "sanitize-filename": "^1.6.3",
     "semver": "^5.3.0",
-    "sqlite3": "^5.0.2"
+    "sqlite3": "^5.0.2",
+    "yargs": "^17.5.0"
   },
   "bin": {
     "export-macos-podcasts": "exportVersionCheck.js"


### PR DESCRIPTION
Building on my prior pull requests :-) this PR adds options to index.js so that I can control the export better.  E.g.:

```
$ node index.js -p tregua -p miedo -o ~/Downloads/some/folder --datesubfolder false --nospaces
```

See the README updates.

ps - I don't know if anyone cares about these updates I'm making, but figure I'll PR them to here as the changes are useful for me, at least!

Cheers, jz